### PR TITLE
AppSec Ingress fixes to make it reachable via LB again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
-terraform.tfvars
+
 
 # .tfstate files
 *.tfstate
@@ -33,5 +33,8 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
 terraform.tfvars
-terraform.tfvars
+inext_1.0.0_darwin_arm64.zip
+ingress-juice.yaml
+ingress1.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ override.tf.json
 .terraformrc
 terraform.rc
 
-terraform.tfvars
+terraform.secret.tfvars
 inext_1.0.0_darwin_arm64.zip
 ingress-juice.yaml
 ingress1.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+terraform.tfvars
 
 # .tfstate files
 *.tfstate
@@ -32,3 +33,5 @@ override.tf.json
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+terraform.tfvars
+terraform.tfvars

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/README.md
+++ b/README.md
@@ -1,101 +1,50 @@
-# CloudGuard Kubernetes Protection
-This Terraform project creates a Kubernetes environment in Azure (AKS) and protects it with Check Point technologies. In this case, we use five different Terraform providers: [Azure](https://registry.terraform.io/providers/hashicorp/azurerm/latest), [Kubernetes](https://registry.terraform.io/providers/hashicorp/kubernetes/latest), [Helm](https://registry.terraform.io/providers/hashicorp/helm/latest), [CloudGuard](https://registry.terraform.io/providers/dome9/dome9/latest), [Infinity-Next](https://registry.terraform.io/providers/CheckPointSW/infinity-next/1.0.0).     
-Once deployed we will have an AKS Cluster with an example application running protected by CloudGuard CSPM, CloudGuard Workload and CloudGuard AppSec.      
-As per my deployments (made in France Central), this project creates all of the following in less than __10 minutes__.    
+# Infinity Next Terraform CLI
+The project provides a command line interface for using the API of Infinity Next
 
-## Which are the components created?
-The project creates the following resources and combines them:
-1. **Azure: AKS Cluster**: it connects to Azure and create a managed instance of Kubernetes (AKS) with its nodepool
-2. **Azure: DNS Zone**: it creates a dns zone in Azure which will then be used to publish the application FQDN
-3. **K8s: Juice Shop Deployment**: it deploys a Juice Shop application on the Kubernetes Cluster 
-4. **Cloudguard CSPM: Cluster Onboarding**: it creates the K8s environment in the CloudGuard Portal for CSPM and Worklaod 
-5. **Cloudguard CSPM: Notification**: it creates a notification to send the findings via mail
-6. **Cloudguard CSPM: Continuous Compliance Policy**: it creates a continuous policy with the Kubernetes Best Practice Ruleset
-7. **INext: Create Appsec Profile**: in Infinity policy portal creates an Appsec Kubernetes profile
-8. **INext: Create Appsec Web Application**: in Infinity policy portal creates the juice shop web app
-9. **Helm: Cloudguard CSPM components**: it creates all the CPSM components needed in AKS using a Helm Chart
-10. **Helm: Cloudguard AppSec components**: it creates all the Appsec components needed in the cluster using a Helm Chart
+## Generating an API Key *(Required)*
+If already have an API key from setting up [terraform-provider-infinity-next](https://github.com/CheckPointSW/terraform-provider-infinity-next) then you can skip this section.
+1. Go to https://portal.checkpoint.com, navigate to *Global Settings -> API Keys*
 
-## How to start?
-First, you need to have a CloudGuard CSPM account, and if you don't, you can create one with these links:
-1. Create an account in [Europe Region](https://secure.eu1.dome9.com/v2/register/invite)
-2. Create an account in [Asia Pacific Region](https://secure.ap1.dome9.com/v2/register/invite)
-3. Create an account in [United States Region](https://secure.dome9.com/v2/register/invite)
+2. Create a new API key and select *Infinity Policy* as the service, with *Admin* role, we recommend that you specify a meaningful comment for the key so you could identify them later and avoid mistakes.
 
-## Get API credentials in your CloudGuard CPSM Portal
-Then you will need to get the API credentials that you will be using with Terraform to onboard the accounts.
+3. Store the *Client ID* and *Secret Key* in a secure location, and note there's no way to view the secret key afterward.
 
-![CSPM Service Account](/zimages/create-cpsm-serviceaccount.jpg)
+## Usage
+First, Download and install the CLI found in the latest release.
 
-Remember to copy these two values! You will need to enter them in the *.tfvars* file later on.
+You could run `inext help` and get all available options and commands.
 
-## Get Appsec API Credential from Check Point Infinity Portal
-You will need to use them for the Infinity Portal configuration, in the INFINITY POLICY application.    
-If you don't have a Portal you can create one following this link: [Register](https://portal.checkpoint.com/create-account)
+The CLI requires the same credentials used to configure the provider, there are 3 options to pass these credentials to the CLI:
 
-Under the Infinity Policy Tab go to "Setting" (bottom left) > "API Keys" > "New"
-The configuration will be done in this section:
-![Appsec API Access](/zimages/create-appsec-service-account.jpg)
+1. Set the environment variables: `INEXT_REGION`, `INEXT_CLIENT_ID` and `INEXT_ACCESS_KEY` and run `inext <command>`, this is more comfortable for usage right after `terraform apply` since it uses the same environment variables.
+   
+2. Set credentials using flags `--client-id` (shorthand `-c`) and `--access-key` (shorthand `-k`)
+   ```
+   inext publish -c $INEXT_CLIENT_ID -k $INEXT_ACCESS_KEY -r us
+   ```
 
-Once created you will be prompted with the API Key & Secret! You will need to enter them in the *.tfvars* file later on.
+3. Create a yaml file at `~/.inext.yaml` with the following content:
+   ```
+   client-id: <INEXT_CLIENT_ID>
+   access-key: <INEXT_ACCESS_KEY>
+   region: eu
+   ```
+   Run `inext <command>` and the CLI would be configured using `~/.inext.yaml` by default, can be set using `inext --config <config-path> <command>`
 
-## How to use it
-In order to use this project you would now need of infinity next Cli Tool and Terraform.     
-Here is why: 
-*"All changes that are made when running terraform apply are done under a session of the configured API key.*     
-*At Infinity Next, each session must be published to be able to enforce your configured policies on your assets. Think of it as commiting your changes to be able to make a release.*      
-*Due to Terraform's lack of concept of session management/commiting changes at the end of an applied configuration, it's required from the user of this provider to publish and enforce the applied configuration by himself."*
-
-In order to configure inext plug in, follow the instruction at [CheckPointSW / terraform-provider-infinity-next](https://github.com/CheckPointSW/terraform-provider-infinity-next) on how to set the credentials and download the tool.
-
-##
-Now you would need to change the __*terraform.tfvars*__ file located in this directory.
-
-```hcl
-# Set in this file your deployment variables
-azure-client-id         = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-client-secret     = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-tenant            = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-subscription      = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-
-location                = "France Central"
-log-analytics-location  = "francecentral"
-mydns-zone              = "<yourzone>.com"
-
-cspm-mail               = "<youremail>@<yourdomain>.com"
-cspm-key-id             = "xxxxxxxxxxxxxx"
-cspm-key-secret         = "xxxxxxxxxxxxxx"
-cspm-org-unit           = "xxxxxxxxxxxxxx"
-
-# CSPM API endpoint: - for US use: 'https://api.dome9.com/v2/'
-#                    - for EU use: 'https://api.eu1.dome9.com/v2/'
-cspm-api-endpoint       = "https://api.dome9.com/v2/"
-# Where is your CSPM platform instanced? usea1 [default], euwe1, apso1
-cspm-residency          = "usea1"
-
-appsec-client-id        = "xxxxxxxxxxxxxx"
-appsec-client-secret    = "xxxxxxxxxxxxxx"
+## Example
 ```
-If you want (or need) to further customize other project details, you can change defaults in the different __*name-variables.tf*__ files.
-Here you will also be able to find the descriptions that explain what each variable is used for.
-
-## Launch terraform to build the infrastructure
-To prepare the current working directory (and install the required providers) run :
-```hcl
-terraform init 
-```
-##
-To apply the changes required to reach the desired state (and create your environment) run :
-```hcl
-terraform apply
 inext publish && inext enforce
 ```
 
-## Terraform Project Outputs
-Once the  project will be applied correctly, you will receive two output with the FQDN to connect to the application.     
-The first is the one where the application lives behind appsec, the second one is the directly exposed application.     
-```hcl
-Outputs:
-juiceshop-protected-fqdn = "http://juiceshop-protected.<yourzone>.com"
-juiceshop-unprotected-fqdn = "http://juiceshop-unprotected.<yourzone>.com"
+## Build
+### Requirements
+* Go 1.18+
+
+To build the CLI run:
+```
+go build -o inext
+```
+You could then install it by running:
+```
+cp inext /usr/local/bin
 ```

--- a/helm-main.tf
+++ b/helm-main.tf
@@ -33,7 +33,7 @@ resource "helm_release" "asset-mgmt" {
 }
 
 resource "helm_release" "ckp-appsec" {
-  name       = "cloudguard-appsec"
+  name       = "appsec"
   chart      = "https://github.com/CheckPointSW/Infinity-Next/raw/main/deployments/cp-k8s-appsec-nginx-ingress-4.1.4.tgz"
   namespace  = "cloudguard-appsec"
   create_namespace = true
@@ -50,6 +50,16 @@ resource "helm_release" "ckp-appsec" {
     name = "controller.ingressClassResource.name"
     value= "nginx"
   }
+  set {
+    name = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-health-probe-request-path"
+    value = "/healthz"
+  }
+
+  # service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+  #   set {
+  #   name = "controller.service.annotations.service\\.beta\\.kubernetes\\.io/azure-load-balancer-internal"
+  #   value = "true"
+  # }
   depends_on = [azurerm_kubernetes_cluster.aks-cluster,inext_kubernetes_profile.appsec-k8s-profile]
 }
 

--- a/k8s-main.tf
+++ b/k8s-main.tf
@@ -93,7 +93,8 @@ resource "kubernetes_ingress_v1" "appsec-ext-ingress" {
       host = "juiceshop-protected.${azurerm_dns_zone.mydns-public-zone.name}"
       http {
         path {
-          path = "/*"
+          path_type = "Prefix"
+          path = "/"
           backend {
             service {
               name = kubernetes_service.app-svc.metadata.0.name

--- a/providers.tf
+++ b/providers.tf
@@ -11,7 +11,7 @@ terraform {
     }
     kubernetes = {
       source = "hashicorp/kubernetes"
-      version = "~> 2.11.2"
+      version = "~> 2.21.1"
     }
     helm = {
       source = "hashicorp/helm"

--- a/terraform copy.tfvars.example
+++ b/terraform copy.tfvars.example
@@ -1,0 +1,24 @@
+# Set in this file your deployment variables
+
+azure-client-secret  = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/client-secret"
+azure-client-id= "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/client-id"
+azure-tenant  = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/tenant-id"
+azure-subscription = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/subscription"
+
+location                = "France Central"
+log-analytics-location  = "francecentral"
+mydns-zone              = "aks.klaud.online"
+
+cspm-mail           = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/mail"
+cspm-key-id         = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/sa-key"
+cspm-key-secret     = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/sa-secret"
+cspm-org-unit       = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/org-unit-id"
+
+# CSPM API endpoint: - for US use: 'https://api.dome9.com/v2/'
+#                    - for EU use: 'https://api.eu1.dome9.com/v2/'
+cspm-api-endpoint   = "https://api.eu1.dome9.com/v2/"
+# Where is your CSPM platform instanced? usea1 [default], euwe1, apso1
+cspm-residency      = "euwe1"
+
+appsec-client-id    = "op://Personal/mtest2.appsec/Section_tqu2voz25llbfsaw4sfhot4cte/clientid"
+appsec-client-secret= "op://Personal/mtest2.appsec/Section_tqu2voz25llbfsaw4sfhot4cte/secret"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,23 +1,24 @@
 # Set in this file your deployment variables
-azure-client-id     = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-client-secret = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-tenant        = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-azure-subscription  = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+
+azure-client-secret  = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/client-secret"
+azure-client-id= "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/client-id"
+azure-tenant  = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/tenant-id"
+azure-subscription = "op://Personal/cp.azure/Section_qqobzr2335ybg36tsl4akfmarm/subscription"
 
 location                = "France Central"
 log-analytics-location  = "francecentral"
-mydns-zone              = "<yourzone>.com"
+mydns-zone              = "aks.klaud.online"
 
-cspm-mail           = "<youremail>@<yourdomain>.com"
-cspm-key-id         = "xxxxxxxxxxxxxx"
-cspm-key-secret     = "xxxxxxxxxxxxxx"
-cspm-org-unit       = "xxxxxxxxxxxxxx"
+cspm-mail           = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/mail"
+cspm-key-id         = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/sa-key"
+cspm-key-secret     = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/sa-secret"
+cspm-org-unit       = "op://Personal/mtest2.cnapp/Section_ekxyrlmc2ekloxnkpozre5xsea/org-unit-id"
 
 # CSPM API endpoint: - for US use: 'https://api.dome9.com/v2/'
 #                    - for EU use: 'https://api.eu1.dome9.com/v2/'
-cspm-api-endpoint   = "https://api.dome9.com/v2/"
+cspm-api-endpoint   = "https://api.eu1.dome9.com/v2/"
 # Where is your CSPM platform instanced? usea1 [default], euwe1, apso1
-cspm-residency      = "usea1"
+cspm-residency      = "euwe1"
 
-appsec-client-id    = "xxxxxxxxxxxxxx"
-appsec-client-secret= "xxxxxxxxxxxxxx"
+appsec-client-id    = "op://Personal/mtest2.appsec/Section_tqu2voz25llbfsaw4sfhot4cte/clientid"
+appsec-client-secret= "op://Personal/mtest2.appsec/Section_tqu2voz25llbfsaw4sfhot4cte/secret"


### PR DESCRIPTION
I would suggest fixes for AKS Ingress with AppSec:
- k8s-main.tf: Ingress definition
- helm-main.tf: annotation to make Ingress reachable on Public IP and shorter name to fit into name length limit
- providers.tf: kubernetes provider version was not available

Why: 
- repo was not used for some time and it stopped working:
  - Ingress with AppSec was not reachable
  - deployment failed because of name length limit of AppSec deployment name